### PR TITLE
fix: 增加无法收到验证码的处理方式说明

### DIFF
--- a/pages/register.vue
+++ b/pages/register.vue
@@ -35,7 +35,7 @@
       </z-input>
       <z-input
         v-model="sms"
-        label="验证码"
+        label="验证码（若无法接收验证码，请入招新群973508852处理）"
         minlength="6"
         maxlength="6"
         type="number"


### PR DESCRIPTION
2025-9秋招留 部分运营商无法接受验证码 选择手动通知新生添加2025秋招通知群